### PR TITLE
Added StyleCop and fixed braking styles.

### DIFF
--- a/Dache.Board/Configuration/DacheboardConfigurationSection.cs
+++ b/Dache.Board/Configuration/DacheboardConfigurationSection.cs
@@ -11,78 +11,63 @@ namespace Dache.Board.Configuration
         private static readonly DacheboardConfigurationSection _settings = ConfigurationManager.GetSection("dacheboardSettings") as DacheboardConfigurationSection;
 
         /// <summary>
-        /// The Dacheboard settings.
+        /// Gets Dacheboard settings.
         /// </summary>
         public static DacheboardConfigurationSection Settings
         {
-            get
-            {
-                return _settings;
-            }
+            get { return _settings; }
         }
 
         /// <summary>
-        /// The Dacheboard address.
+        /// Gets or sets Dacheboard address.
         /// </summary>
         [StringValidator(InvalidCharacters = @"\:")]
         [ConfigurationProperty("address", IsRequired = true)]
         public string Address
         {
-            get
-            {
-                return (string)this["address"];
-            }
-            set
-            {
-                this["address"] = value;
-            }
+            get { return (string)this["address"]; }
+            set { this["address"] = value; }
         }
 
         /// <summary>
-        /// The Dacheboard port.
+        /// Gets or sets Dacheboard port.
         /// </summary>
         [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
         [ConfigurationProperty("port", IsRequired = true, DefaultValue = 33333)]
         public int Port
         {
-            get
-            {
-                return (int)this["port"];
-            }
-            set
-            {
-                this["port"] = value;
-            }
+            get { return (int)this["port"]; }
+            set { this["port"] = value; }
         }
 
         /// <summary>
-        /// How often to attempt to re-establish the connection to the disconnected cache manager, in milliseconds.
+        /// Gets the manager reconnect interval in milliseconds.
         /// </summary>
+        /// <value>
+        /// The manager reconnect interval milliseconds.
+        /// </value>
+        /// <remarks>
+        /// How often to attempt to re-establish the connection to the disconnected cache manager, in milliseconds.
+        /// </remarks>
         [IntegerValidator(MinValue = 1000, MaxValue = 60000)]
         [ConfigurationProperty("managerReconnectIntervalMilliseconds", IsRequired = true, DefaultValue = 5000)]
         public int ManagerReconnectIntervalMilliseconds
         {
-            get
-            {
-                return (int)this["managerReconnectIntervalMilliseconds"];
-            }
+            get { return (int)this["managerReconnectIntervalMilliseconds"]; }
         }
 
         /// <summary>
-        /// The Dacheboard information polling interval in milliseconds. Valid range is 1000 to 60000.
+        /// Gets or sets the information polling interval in milliseconds.
         /// </summary>
+        /// <value>
+        /// The Dacheboard information polling interval in milliseconds. Valid range is 1000 to 60000.
+        /// </value>
         [IntegerValidator(MinValue = 1000, MaxValue = 60000)]
         [ConfigurationProperty("informationPollingIntervalMilliseconds", IsRequired = true, DefaultValue = 1000)]
         public int InformationPollingIntervalMilliseconds
         {
-            get
-            {
-                return (int)this["informationPollingIntervalMilliseconds"];
-            }
-            set
-            {
-                this["informationPollingIntervalMilliseconds"] = value;
-            }
+            get { return (int)this["informationPollingIntervalMilliseconds"]; }
+            set { this["informationPollingIntervalMilliseconds"] = value; }
         }
     }
 }

--- a/Dache.Board/Controllers/AjaxCacheInfoController.cs
+++ b/Dache.Board/Controllers/AjaxCacheInfoController.cs
@@ -11,7 +11,7 @@ namespace Dache.Board.Controllers
         /// <summary>
         /// Creates a cache info JSON object.
         /// </summary>
-        /// <returns>The JSON.</returns>
+        /// <returns>The response in form of a JSON.</returns>
         public JsonResult CacheInfo()
         {
             // Get the cache info

--- a/Dache.Board/Controllers/BoardController.cs
+++ b/Dache.Board/Controllers/BoardController.cs
@@ -10,7 +10,7 @@ namespace Dache.Board.Controllers
         /// <summary>
         /// Creates the index view.
         /// </summary>
-        /// <returns>The view.</returns>
+        /// <returns>BoardController index view.</returns>
         public ActionResult Index()
         {
             return View();

--- a/Dache.Board/Controllers/ErrorController.cs
+++ b/Dache.Board/Controllers/ErrorController.cs
@@ -10,7 +10,7 @@ namespace Dache.Board.Controllers
         /// <summary>
         /// Creates the 404 not found view.
         /// </summary>
-        /// <returns>The view.</returns>
+        /// <returns>The error view.</returns>
         public ActionResult NotFound()
         {
             return View();

--- a/Dache.Board/Dache.Board.csproj
+++ b/Dache.Board/Dache.Board.csproj
@@ -26,6 +26,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <NuGetPackageImportStamp>9998388c</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -224,6 +225,7 @@
     <Content Include="Views\Shared\Error.cshtml" />
     <Content Include="Views\Shared\_Layout.cshtml" />
     <Content Include="Scripts\jquery-2.1.0.min.map" />
+    <Content Include="Settings.StyleCop" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
@@ -270,6 +272,13 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Dache.Board/Global.asax.cs
+++ b/Dache.Board/Global.asax.cs
@@ -42,21 +42,18 @@ namespace Dache.Board
 
             routes.MapRoute(
                 name: "Home",
-                url: "",
-                defaults: new { controller = "Board", action = "Index", pageTitle = "What's Happening" }
-            );
+                url: string.Empty,
+                defaults: new { controller = "Board", action = "Index", pageTitle = "What's Happening" });
 
             routes.MapRoute(
                 "AJAX Cache Info", // Route name
                 "ajax/cacheinfo", // URL with parameters
-                new { controller = "AjaxCacheInfo", action = "CacheInfo" } // Parameter defaults
-            );
+                new { controller = "AjaxCacheInfo", action = "CacheInfo" }); // Parameter defaults
 
             routes.MapRoute(
                 name: "404",
                 url: "{*anything}",
-                defaults: new { controller = "Error", action = "NotFound", pageTitle = "Not Found" }
-            );
+                defaults: new { controller = "Error", action = "NotFound", pageTitle = "Not Found" });
         }
 
         /// <summary>
@@ -73,13 +70,13 @@ namespace Dache.Board
             var address = DacheboardConfigurationSection.Settings.Address;
             var port = DacheboardConfigurationSection.Settings.Port;
             var managerReconnectIntervalMilliseconds = DacheboardConfigurationSection.Settings.ManagerReconnectIntervalMilliseconds;
-            
+
             // Build the endpoint address
             var endpointAddressFormattedString = "net.tcp://{0}:{1}/Dache/Dacheboard";
             var managerAddress = string.Format(endpointAddressFormattedString, address, port);
 
             // TODO: initialize dache board cache host client here?
-            //BoardToManagerClientContainer.Instance = new BoardToManagerClient(managerAddress, managerReconnectIntervalMilliseconds);
+            // BoardToManagerClientContainer.Instance = new BoardToManagerClient(managerAddress, managerReconnectIntervalMilliseconds);
         }
     }
 }

--- a/Dache.Board/Handlers/CacheInfoHandler.cs
+++ b/Dache.Board/Handlers/CacheInfoHandler.cs
@@ -12,11 +12,12 @@ namespace Dache.Board.Handlers
     {
         // The timer which updates cache information
         private static readonly Timer _updateCacheInformationTimer = null;
+
         // The current cache information
         private static IList<KeyValuePair<string, PerformanceCounter[]>> _currentCacheInformation = null;
 
         /// <summary>
-        /// Static constructor.
+        /// Initializes static members of the <see cref="CacheInfoHandler"/> class.
         /// </summary>
         static CacheInfoHandler()
         {
@@ -25,6 +26,7 @@ namespace Dache.Board.Handlers
 
             // Get the timer interval from configuration
             var timerInterval = DacheboardConfigurationSection.Settings.InformationPollingIntervalMilliseconds;
+            
             // Configure the timer to fire according to the configuration
             _updateCacheInformationTimer = new Timer(UpdateCacheInformationThread, null, timerInterval, timerInterval);
         }
@@ -45,11 +47,11 @@ namespace Dache.Board.Handlers
         private static void UpdateCacheInformationThread(object state)
         {
             // Lock to prevent concurrent hits if the thread rolls over itself
-            lock (_currentCacheInformation)
-            {
+            // lock (_currentCacheInformation)
+            // {
                 // TODO: get information from the cache hosts
-                //_currentCacheInformation = BoardToManagerClientContainer.Instance.GetPerformanceInformation();
-            }
+                // _currentCacheInformation = BoardToManagerClientContainer.Instance.GetPerformanceInformation();
+            // }
         }
     }
 }

--- a/Dache.Board/Settings.StyleCop
+++ b/Dache.Board/Settings.StyleCop
@@ -1,0 +1,6 @@
+﻿<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <StringProperty Name="LinkedSettingsFile">..\Settings.StyleCop</StringProperty>
+    <StringProperty Name="MergeSettingsFiles">Linked</StringProperty>
+  </GlobalSettings>
+</StyleCopSettings>

--- a/Dache.Board/packages.config
+++ b/Dache.Board/packages.config
@@ -7,4 +7,5 @@
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
+  <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/Dache.CacheHost/CacheHostEngine.cs
+++ b/Dache.CacheHost/CacheHostEngine.cs
@@ -10,11 +10,12 @@ namespace Dache.CacheHost
     {
         // The cache server
         private readonly IRunnable _cacheServer = null;
+
         // The cache host information poller
         private readonly IRunnable _cacheHostInformationPoller = null;
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="CacheHostEngine"/> class.
         /// </summary>
         /// <param name="cacheHostInformationPoller">The cache host information poller.</param>
         /// <param name="cacheHostServer">The cache host server.</param>
@@ -25,6 +26,7 @@ namespace Dache.CacheHost
             {
                 throw new ArgumentNullException("cacheHostInformationPoller");
             }
+
             if (cacheHostServer == null)
             {
                 throw new ArgumentNullException("cacheHostServer");

--- a/Dache.CacheHost/CacheHostService.cs
+++ b/Dache.CacheHost/CacheHostService.cs
@@ -24,21 +24,7 @@ namespace Dache.CacheHost
         private IRunnable _cacheHostEngine = null;
 
         /// <summary>
-        /// The main entry point for the application.
-        /// </summary>
-        /// <param name="args">The arguments passed, if any.</param>
-        static void Main(string[] args)
-        {
-            var servicesToRun = new ServiceBase[] 
-            { 
-                new CacheHostService()
-            };
-
-            ServiceBase.Run(servicesToRun);
-        }
-
-        /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="CacheHostService"/> class.
         /// </summary>
         public CacheHostService()
         {
@@ -131,6 +117,20 @@ namespace Dache.CacheHost
             {
                 // Ignore it - stopping anyway
             }
+        }
+
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        /// <param name="args">The arguments passed, if any.</param>
+        private static void Main(string[] args)
+        {
+            var servicesToRun = new ServiceBase[] 
+            { 
+                new CacheHostService()
+            };
+
+            ServiceBase.Run(servicesToRun);
         }
     }
 }

--- a/Dache.CacheHost/Configuration/CacheHostConfigurationSection.cs
+++ b/Dache.CacheHost/Configuration/CacheHostConfigurationSection.cs
@@ -15,77 +15,68 @@ namespace Dache.CacheHost.Configuration
         private static readonly CacheHostConfigurationSection _settings = ConfigurationManager.GetSection("cacheHostSettings") as CacheHostConfigurationSection;
 
         /// <summary>
-        /// The cache host settings.
+        /// Gets the cache host settings.
         /// </summary>
+        /// <value>
+        /// The cache host settings.
+        /// </value>
         public static CacheHostConfigurationSection Settings
         {
-            get
-            {
-                return _settings;
-            }
+            get { return _settings; }
         }
 
         /// <summary>
-        /// The custom logger.
+        /// Gets the custom logger.
         /// </summary>
+        /// <value>
+        /// The custom logger.
+        /// </value>
         [ConfigurationProperty("customLogger", IsRequired = false)]
         public CustomTypeElement CustomLogger
         {
-            get
-            {
-                return (CustomTypeElement)this["customLogger"];
-            }
+            get { return (CustomTypeElement)this["customLogger"]; }
         }
 
         /// <summary>
-        /// The cache host port.
+        /// Gets or sets the cache host port.
         /// </summary>
+        /// <value>
+        /// The cache host port.
+        /// </value>
         [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
         [ConfigurationProperty("port", IsRequired = true, DefaultValue = 33333)]
         public int Port
         {
-            get
-            {
-                return (int)this["port"];
-            }
-            set
-            {
-                this["port"] = value;
-            }
+            get { return (int)this["port"]; }
+            set { this["port"] = value; }
         }
 
         /// <summary>
-        /// The cache memory limit, as a percentage of the total system memory. Valid range is 20 to 90.
+        /// Gets or sets the cache memory limit, as a percentage of the total system memory. Valid range is 20 to 90.
         /// </summary>
+        /// <value>
+        /// The cache memory limit percentage.
+        /// </value>
         [IntegerValidator(MinValue = 5, MaxValue = 90)]
         [ConfigurationProperty("cacheMemoryLimitPercentage", IsRequired = true, DefaultValue = 80)]
         public int CacheMemoryLimitPercentage
         {
-            get
-            {
-                return (int)this["cacheMemoryLimitPercentage"];
-            }
-            set
-            {
-                this["cacheMemoryLimitPercentage"] = value;
-            }
+            get { return (int)this["cacheMemoryLimitPercentage"]; }
+            set { this["cacheMemoryLimitPercentage"] = value; }
         }
 
         /// <summary>
         /// Gets or sets the storage provider.
         /// </summary>
+        /// <value>
+        /// The storage provider.
+        /// </value>
         [TypeConverter(typeof(TypeNameConverter))]
         [ConfigurationProperty("storageProvider", IsRequired = false, DefaultValue = typeof(MemCache))]
         public Type StorageProvider
         {
-            get
-            {
-                return this["storageProvider"] as Type;
-            }
-            set
-            {
-                this["storageProvider"] = value;
-            }
+            get { return this["storageProvider"] as Type; }
+            set { this["storageProvider"] = value; }
         }
     }
 }

--- a/Dache.CacheHost/Configuration/CustomLoggerLoader.cs
+++ b/Dache.CacheHost/Configuration/CustomLoggerLoader.cs
@@ -15,12 +15,12 @@ namespace Dache.CacheHost.Configuration
         public static ILogger LoadLogger()
         {
             var defaultLogger = new EventViewerLogger("Cache Host", "Dache");
-            //var defaultLogger = new FileLogger();
 
             // Configure custom logging
             try
             {
                 var customLoggerTypeString = CacheHostConfigurationSection.Settings.CustomLogger.Type;
+
                 // Check for custom logger
                 if (string.IsNullOrWhiteSpace(customLoggerTypeString))
                 {
@@ -30,6 +30,7 @@ namespace Dache.CacheHost.Configuration
 
                 // Have a custom logger, attempt to load it and confirm it
                 var customLoggerType = Type.GetType(customLoggerTypeString);
+                
                 // Verify that it implements our ILogger interface
                 if (customLoggerType != null && typeof(ILogger).IsAssignableFrom(customLoggerType))
                 {
@@ -38,8 +39,8 @@ namespace Dache.CacheHost.Configuration
             }
             catch (Exception ex)
             {
-                defaultLogger.Error(ex);
                 // Custom logger load failed - no custom logging
+                defaultLogger.Error(ex);
             }
 
             return defaultLogger;

--- a/Dache.CacheHost/CustomInstaller.cs
+++ b/Dache.CacheHost/CustomInstaller.cs
@@ -15,19 +15,23 @@ namespace Dache.CacheHost
     [RunInstaller(true)]
     public class CustomInstaller : Installer
     {
-        // The service installer
-        private ServiceInstaller _serviceInstaller = new ServiceInstaller();
-        // The service process installer
-        private ServiceProcessInstaller _serviceProcessInstaller = new ServiceProcessInstaller();
-        // The service version
-        private Version _serviceVersion = null;
         // The settings file name
         private const string _settingsFileName = "settings";
+        
         // A line of stars for the console output
         private const string _consoleLineOfStars = "******************************************************************************";
+        
+        // The service installer
+        private ServiceInstaller _serviceInstaller = new ServiceInstaller();
+        
+        // The service process installer
+        private ServiceProcessInstaller _serviceProcessInstaller = new ServiceProcessInstaller();
+        
+        // The service version
+        private Version _serviceVersion = null;
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="CustomInstaller"/> class.
         /// </summary>
         public CustomInstaller()
         {
@@ -36,12 +40,13 @@ namespace Dache.CacheHost
             _serviceVersion = Assembly.GetExecutingAssembly().GetName().Version;
 
             // Set some service information
-            _serviceInstaller.DisplayName = serviceName; //+ " " + _serviceVersion;
-            _serviceInstaller.ServiceName = serviceName; //+ " " + _serviceVersion;
+            _serviceInstaller.DisplayName = serviceName; // + " " + _serviceVersion;
+            _serviceInstaller.ServiceName = serviceName; // + " " + _serviceVersion;
             _serviceInstaller.StartType = System.ServiceProcess.ServiceStartMode.Automatic;
 
             // Perform install customizations
             BeforeInstall += CustomInstaller_BeforeInstall;
+            
             // Perform rollback uninstall
             AfterRollback += CustomInstaller_BeforeUninstall;
 
@@ -112,6 +117,7 @@ namespace Dache.CacheHost
             {
                 var installPath = Path.Combine(new FileInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).DirectoryName, _settingsFileName);
                 settings = File.ReadAllText(installPath);
+                
                 // Delete this file
                 File.Delete(installPath);
             }

--- a/Dache.CacheHost/Dache.CacheHost.csproj
+++ b/Dache.CacheHost/Dache.CacheHost.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>4974859a</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -89,11 +90,19 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
+    <None Include="Settings.StyleCop" />
     <None Include="uninstall.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Dache.CacheHost/Polling/CacheHostInformationPoller.cs
+++ b/Dache.CacheHost/Polling/CacheHostInformationPoller.cs
@@ -14,17 +14,21 @@ namespace Dache.CacheHost.Polling
     {
         // The mem cache
         private readonly IMemCache _memCache = null;
+
         // The custom performance counter manager
         private readonly ICustomPerformanceCounterManager _customPerformanceCounterManager = null;
+
         // The polling interval in milliseconds
         private readonly int _pollingIntervalMilliseconds = 0;
+
         // The cache host information polling timer
         private readonly Timer _cacheHostInformationPollingTimer = null;
+
         // The performance counter for the process' current memory
         private readonly PerformanceCounter _currentMemoryPerformanceCounter = new PerformanceCounter("Process", "Private Bytes", Process.GetCurrentProcess().ProcessName, true);
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="CacheHostInformationPoller"/> class.
         /// </summary>
         /// <param name="memCache">The mem cache.</param>
         /// <param name="customPerformanceCounterManager">The custom performance counter manager.</param>
@@ -36,10 +40,12 @@ namespace Dache.CacheHost.Polling
             {
                 throw new ArgumentNullException("memCache");
             }
+
             if (customPerformanceCounterManager == null)
             {
                 throw new ArgumentNullException("customPerformanceCounterManager");
             }
+
             if (pollingIntervalMilliseconds <= 0)
             {
                 throw new ArgumentException("Interval must be > 0", "pollingIntervalMilliseconds");

--- a/Dache.CacheHost/Settings.StyleCop
+++ b/Dache.CacheHost/Settings.StyleCop
@@ -1,0 +1,6 @@
+﻿<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <StringProperty Name="LinkedSettingsFile">..\Settings.StyleCop</StringProperty>
+    <StringProperty Name="MergeSettingsFiles">Linked</StringProperty>
+  </GlobalSettings>
+</StyleCopSettings>

--- a/Dache.CacheHost/Storage/GZipMemCache.cs
+++ b/Dache.CacheHost/Storage/GZipMemCache.cs
@@ -25,6 +25,28 @@ namespace Dache.CacheHost.Storage
         }
 
         /// <summary>
+        /// Gets the total number of objects in the cache.
+        /// </summary>
+        public long Count
+        {
+            get
+            {
+                return _memCache.Count;
+            }
+        }
+
+        /// <summary>
+        /// Gets the amount of memory on the computer, in megabytes, that can be used by the cache.
+        /// </summary>
+        public long MemoryLimit
+        {
+            get
+            {
+                return _memCache.MemoryLimit;
+            }
+        }
+
+        /// <summary>
         /// Inserts or updates a byte array in the cache at the given key with the specified cache item policy.
         /// </summary>
         /// <param name="key">The key of the byte array. Null is not supported.</param>
@@ -40,11 +62,13 @@ namespace Dache.CacheHost.Storage
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "key");
             }
+
             if (value == null)
             {
                 // GZipMemCache does not support null values
                 throw new ArgumentNullException("value");
             }
+
             if (cacheItemPolicy == null)
             {
                 throw new ArgumentNullException("cacheItemPolicy");
@@ -69,6 +93,7 @@ namespace Dache.CacheHost.Storage
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "key");
             }
+
             if (value == null)
             {
                 // GZipMemCache does not support null values
@@ -110,7 +135,7 @@ namespace Dache.CacheHost.Storage
         }
 
         /// <summary>
-        /// Clears the cache
+        /// Clears the cache.
         /// </summary>
         public void Clear()
         {
@@ -118,33 +143,15 @@ namespace Dache.CacheHost.Storage
         }
 
         /// <summary>
-        /// Gets all the keys in the cache. WARNING: this is likely a very expensive operation for large caches. 
+        /// Gets all the keys in the cache. WARNING: this is likely a very expensive operation for large caches.
         /// </summary>
+        /// <param name="pattern">The search pattern (regex).</param>
+        /// <returns>
+        /// The list of keys matching the provided pattern.
+        /// </returns>
         public IList<string> Keys(string pattern)
         {
             return _memCache.Keys(pattern);
-        }
-
-        /// <summary>
-        /// Total number of objects in the cache.
-        /// </summary>
-        public long Count
-        {
-            get
-            { 
-                return _memCache.Count;
-            }
-        }
-
-        /// <summary>
-        /// Gets the amount of memory on the computer, in megabytes, that can be used by the cache.
-        /// </summary>
-        public long MemoryLimit
-        {
-            get
-            { 
-                return _memCache.MemoryLimit;
-            }
         }
 
         /// <summary>

--- a/Dache.CacheHost/Storage/IMemCache.cs
+++ b/Dache.CacheHost/Storage/IMemCache.cs
@@ -10,6 +10,16 @@ namespace Dache.CacheHost.Storage
     public interface IMemCache : IDisposable
     {
         /// <summary>
+        /// Gets the total number of objects in the cache.
+        /// </summary>
+        long Count { get; }
+
+        /// <summary>
+        /// Gets the amount of memory on the computer, in megabytes, that can be used by the cache.
+        /// </summary>
+        long MemoryLimit { get; }
+
+        /// <summary>
         /// Inserts or updates a byte array in the cache at the given key with the specified cache item policy.
         /// </summary>
         /// <param name="key">The key of the byte array.</param>
@@ -40,25 +50,15 @@ namespace Dache.CacheHost.Storage
         byte[] Remove(string key);
 
         /// <summary>
-        /// Clears the cache
+        /// Clears the cache.
         /// </summary>
         void Clear();
 
         /// <summary>
         /// Gets all the keys in the cache matching the provided pattern. WARNING: this is likely a very expensive operation for large caches. 
         /// </summary>
-        /// <param name="pattern">The search pattern (regex)</param>
-        /// <returns>The list of keys matching the provided pattern</returns>
+        /// <param name="pattern">The search pattern (regex).</param>
+        /// <returns>The list of keys matching the provided pattern.</returns>
         IList<string> Keys(string pattern);
-
-        /// <summary>
-        /// Total number of objects in the cache.
-        /// </summary>
-        long Count { get; }
-
-        /// <summary>
-        /// Gets the amount of memory on the computer, in megabytes, that can be used by the cache.
-        /// </summary>
-        long MemoryLimit { get; }
     }
 }

--- a/Dache.CacheHost/packages.config
+++ b/Dache.CacheHost/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="SharpMemoryCache" version="1.0.0" targetFramework="net45" />
   <package id="SimplSockets" version="1.1.1" targetFramework="net45" />
+  <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Dache.Client/Configuration/CacheClientConfigurationSection.cs
+++ b/Dache.Client/Configuration/CacheClientConfigurationSection.cs
@@ -11,7 +11,7 @@ namespace Dache.Client.Configuration
         private static readonly CacheClientConfigurationSection _settings = ConfigurationManager.GetSection("cacheClientSettings") as CacheClientConfigurationSection;
         
         /// <summary>
-        /// The cache host settings.
+        /// Gets the cache host settings.
         /// </summary>
         public static CacheClientConfigurationSection Settings
         {
@@ -22,8 +22,14 @@ namespace Dache.Client.Configuration
         }
 
         /// <summary>
-        /// How often to attempt to re-establish the connection to a disconnected cache host, in seconds.
+        /// Gets the host reconnect interval expressed in seconds.
         /// </summary>
+        /// <value>
+        /// The host reconnect interval in seconds.
+        /// </value>
+        /// <remarks>
+        /// How often to attempt to re-establish the connection to a disconnected cache host, in seconds.
+        /// </remarks>
         [IntegerValidator(MinValue = 1, MaxValue = 300)]
         [ConfigurationProperty("hostReconnectIntervalSeconds", IsRequired = true, DefaultValue = 10)]
         public int HostReconnectIntervalSeconds
@@ -35,8 +41,14 @@ namespace Dache.Client.Configuration
         }
 
         /// <summary>
-        /// The local cache memory limit, as a percentage of the total system memory. Valid range is 20 to 90.
+        /// Gets the local cache memory limit percentage.
         /// </summary>
+        /// <value>
+        /// The local cache memory limit percentage.
+        /// </value>
+        /// <remarks>
+        /// The local cache memory limit, as a percentage of the total system memory. Valid range is 20 to 90.
+        /// </remarks>
         [IntegerValidator(MinValue = 5, MaxValue = 90)]
         [ConfigurationProperty("localCacheMemoryLimitPercentage", IsRequired = true, DefaultValue = 80)]
         public int LocalCacheMemoryLimitPercentage
@@ -48,8 +60,14 @@ namespace Dache.Client.Configuration
         }
 
         /// <summary>
-        /// When to expire locally cached entries, in seconds.
+        /// Gets the local cache absolute expiration expressed in seconds.
         /// </summary>
+        /// <value>
+        /// The local cache absolute expiration in seconds.
+        /// </value>
+        /// <remarks>
+        /// When to expire locally cached entries, in seconds.
+        /// </remarks>
         [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
         [ConfigurationProperty("localCacheAbsoluteExpirationSeconds", IsRequired = true, DefaultValue = 10)]
         public int LocalCacheAbsoluteExpirationSeconds
@@ -61,8 +79,11 @@ namespace Dache.Client.Configuration
         }
 
         /// <summary>
-        /// The custom logger.
+        /// Gets the custom logger.
         /// </summary>
+        /// <value>
+        /// The custom logger.
+        /// </value>
         [ConfigurationProperty("customLogger", IsRequired = false)]
         public CustomTypeElement CustomLogger
         {
@@ -73,8 +94,11 @@ namespace Dache.Client.Configuration
         }
 
         /// <summary>
-        /// The custom serializer.
+        /// Gets the custom serializer.
         /// </summary>
+        /// <value>
+        /// The custom serializer.
+        /// </value>
         [ConfigurationProperty("customSerializer", IsRequired = false)]
         public CustomTypeElement CustomSerializer
         {
@@ -85,8 +109,11 @@ namespace Dache.Client.Configuration
         }
 
         /// <summary>
-        /// The cache hosts collection.
+        /// Gets the cache hosts collection.
         /// </summary>
+        /// <value>
+        /// The cache hosts collection.
+        /// </value>
         [ConfigurationProperty("cacheHosts", IsDefaultCollection = false)]
         [ConfigurationCollection(typeof(CacheHostsCollection), AddItemName = "add", RemoveItemName = "remove", ClearItemsName = "clear")]
         public CacheHostsCollection CacheHosts

--- a/Dache.Client/Configuration/CacheHostElement.cs
+++ b/Dache.Client/Configuration/CacheHostElement.cs
@@ -8,37 +8,31 @@ namespace Dache.Client.Configuration
     public class CacheHostElement : ConfigurationElement
     {
         /// <summary>
-        /// The cache host address.
+        /// Gets or sets the cache host address.
         /// </summary>
+        /// <value>
+        /// The cache host address.
+        /// </value>
         [StringValidator(InvalidCharacters = @"\:")]
         [ConfigurationProperty("address", IsRequired = true)]
         public string Address
         {
-            get
-            {
-                return (string)this["address"];
-            }
-            set
-            {
-                this["address"] = value;
-            }
+            get { return (string)this["address"]; }
+            set { this["address"] = value; }
         }
 
         /// <summary>
-        /// The cache host port.
+        /// Gets or sets the cache host port.
         /// </summary>
+        /// <value>
+        /// The cache host port.
+        /// </value>
         [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
         [ConfigurationProperty("port", IsRequired = true, DefaultValue = 33333)]
         public int Port
         {
-            get
-            {
-                return (int)this["port"];
-            }
-            set
-            {
-                this["port"] = value;
-            }
+            get { return (int)this["port"]; }
+            set { this["port"] = value; }
         }
     }
 }

--- a/Dache.Client/Configuration/CacheHostsCollection.cs
+++ b/Dache.Client/Configuration/CacheHostsCollection.cs
@@ -8,23 +8,28 @@ namespace Dache.Client.Configuration
     public class CacheHostsCollection : ConfigurationElementCollection
     {
         /// <summary>
-        /// Creates a new cache host element.
+        /// Gets the number of cache host elements.
         /// </summary>
-        /// <returns>A new cache host element.</returns>
-        protected override ConfigurationElement CreateNewElement()
+        public new int Count
         {
-            return new CacheHostElement();
+            get
+            {
+                return base.Count;
+            }
         }
 
         /// <summary>
-        /// Gets the key of a given configuration element.
+        /// Gets a value indicating whether or not the cache host element collection is read only.
         /// </summary>
-        /// <param name="element">The configuration element.</param>
-        /// <returns>The key.</returns>
-        protected override object GetElementKey(ConfigurationElement element)
+        /// <value>
+        /// <c>true</c> if the cache host element collection is read only; otherwise, <c>false</c>.
+        /// </value>
+        public new bool IsReadOnly
         {
-            CacheHostElement service = (CacheHostElement)element;
-            return service.Address + ":" + service.Port;
+            get
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -34,11 +39,12 @@ namespace Dache.Client.Configuration
         /// <returns>The cache host element.</returns>
         public CacheHostElement this[int index]
         {
-            get
-            {
-                return (CacheHostElement)BaseGet(index);
+            get 
+            { 
+                return (CacheHostElement)BaseGet(index); 
             }
-            set
+
+            set 
             {
                 if (BaseGet(index) != null)
                 {
@@ -59,17 +65,6 @@ namespace Dache.Client.Configuration
             get
             {
                 return (CacheHostElement)BaseGet(name);
-            }
-        }
-
-        /// <summary>
-        /// Gets the number of cache host elements.
-        /// </summary>
-        public new int Count
-        {
-            get
-            {
-                return base.Count;
             }
         }
 
@@ -130,17 +125,6 @@ namespace Dache.Client.Configuration
         }
 
         /// <summary>
-        /// Whether or not the cache host element collection is read only.
-        /// </summary>
-        public new bool IsReadOnly
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Removes a cache host element from the collection.
         /// </summary>
         /// <param name="item">The cache host element.</param>
@@ -154,6 +138,26 @@ namespace Dache.Client.Configuration
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Creates a new cache host element.
+        /// </summary>
+        /// <returns>A new cache host element.</returns>
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new CacheHostElement();
+        }
+
+        /// <summary>
+        /// Gets the key of a given configuration element.
+        /// </summary>
+        /// <param name="element">The configuration element.</param>
+        /// <returns>The element key.</returns>
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            CacheHostElement service = (CacheHostElement)element;
+            return service.Address + ":" + service.Port;
         }
     }
 }

--- a/Dache.Client/Configuration/CustomTypeElement.cs
+++ b/Dache.Client/Configuration/CustomTypeElement.cs
@@ -8,20 +8,14 @@ namespace Dache.Client.Configuration
     public class CustomTypeElement : ConfigurationElement
     {
         /// <summary>
-        /// The custom type.
+        /// Gets or sets the custom type.
         /// </summary>
         [StringValidator(InvalidCharacters = @"\:")]
         [ConfigurationProperty("type", IsRequired = true)]
         public string Type
         {
-            get
-            {
-                return (string)this["type"];
-            }
-            set
-            {
-                this["type"] = value;
-            }
+            get { return (string)this["type"]; }
+            set { this["type"] = value; }
         }
     }
 }

--- a/Dache.Client/Configuration/CustomTypesLoader.cs
+++ b/Dache.Client/Configuration/CustomTypesLoader.cs
@@ -21,6 +21,7 @@ namespace Dache.Client.Configuration
             try
             {
                 var customLoggerTypeString = CacheClientConfigurationSection.Settings.CustomLogger.Type;
+
                 // Check for custom logger
                 if (string.IsNullOrWhiteSpace(customLoggerTypeString))
                 {
@@ -30,6 +31,7 @@ namespace Dache.Client.Configuration
 
                 // Have a custom logger, attempt to load it and confirm it
                 var customLoggerType = Type.GetType(customLoggerTypeString);
+                
                 // Verify that it implements our ILogger interface
                 if (customLoggerType != null && typeof(ILogger).IsAssignableFrom(customLoggerType))
                 {
@@ -56,6 +58,7 @@ namespace Dache.Client.Configuration
             try
             {
                 var customSerializerTypeString = CacheClientConfigurationSection.Settings.CustomSerializer.Type;
+                
                 // Check for custom serializer
                 if (string.IsNullOrWhiteSpace(customSerializerTypeString))
                 {
@@ -65,13 +68,22 @@ namespace Dache.Client.Configuration
 
                 // Have a custom serializer, attempt to load it and confirm it
                 var customSerializerType = Type.GetType(customSerializerTypeString);
+                
                 // Verify that it implements our IBinarySerializer interface
                 if (customSerializerType != null && typeof(IBinarySerializer).IsAssignableFrom(customSerializerType))
                 {
                     return (IBinarySerializer)Activator.CreateInstance(customSerializerType);
                 }
-                if (customSerializerType == null) { throw new Exception("custom serializer is null"); }
-                if (!customSerializerType.IsAssignableFrom(typeof(IBinarySerializer))) { throw new Exception("custom serializer is not of type IBinarySerializer"); }
+
+                if (customSerializerType == null) 
+                { 
+                    throw new Exception("custom serializer is null"); 
+                }
+
+                if (!customSerializerType.IsAssignableFrom(typeof(IBinarySerializer))) 
+                { 
+                    throw new Exception("custom serializer is not of type IBinarySerializer"); 
+                }
             }
             catch (Exception ex)
             {

--- a/Dache.Client/Dache.Client.csproj
+++ b/Dache.Client/Dache.Client.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>8cee201d</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -77,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Settings.StyleCop" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dache.Core\Dache.Core.csproj">
@@ -85,6 +87,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Dache.Client/Exceptions/NoCacheHostsAvailableException.cs
+++ b/Dache.Client/Exceptions/NoCacheHostsAvailableException.cs
@@ -10,43 +10,39 @@ namespace Dache.Client.Exceptions
     public class NoCacheHostsAvailableException : Exception
     {
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="NoCacheHostsAvailableException"/> class.
         /// </summary>
         public NoCacheHostsAvailableException()
             : base()
         {
-
         }
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="NoCacheHostsAvailableException"/> class.
         /// </summary>
         /// <param name="message">The message.</param>
         public NoCacheHostsAvailableException(string message)
             : base(message)
         {
-
         }
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="NoCacheHostsAvailableException"/> class.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
         public NoCacheHostsAvailableException(string message, Exception innerException)
             : base(message, innerException)
         {
-
         }
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="NoCacheHostsAvailableException"/> class.
         /// </summary>
         /// <param name="info">The serialization info.</param>
         /// <param name="context">The streaming context.</param>
         public NoCacheHostsAvailableException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-
         }
     }
 }

--- a/Dache.Client/ICacheClient.cs
+++ b/Dache.Client/ICacheClient.cs
@@ -9,6 +9,16 @@ namespace Dache.Client
     public interface ICacheClient
     {
         /// <summary>
+        /// Event that fires when the cache client is disconnected from a cache host.
+        /// </summary>
+        event EventHandler HostDisconnected;
+
+        /// <summary>
+        /// Event that fires when the cache client is successfully reconnected to a disconnected cache host.
+        /// </summary>
+        event EventHandler HostReconnected;
+
+        /// <summary>
         /// Gets the object stored at the given cache key from the cache.
         /// </summary>
         /// <typeparam name="T">The expected type.</typeparam>
@@ -173,7 +183,7 @@ namespace Dache.Client
         void AddOrUpdateTagged(IEnumerable<KeyValuePair<string, object>> cacheKeysAndObjects, string tagName, DateTimeOffset absoluteExpiration);
 
         /// <summary>
-        /// Adds or updates many objects in the cache at thr given cache keys with the associated tag name.
+        /// Adds or updates many objects in the cache at the given cache keys with the associated tag name.
         /// </summary>
         /// <param name="cacheKeysAndObjects">The cache keys and their associated objects.</param>
         /// <param name="tagName">The tag name.</param>
@@ -247,15 +257,5 @@ namespace Dache.Client
         /// Clears the cache.
         /// </summary>
         void Clear();
-
-        /// <summary>
-        /// Event that fires when the cache client is disconnected from a cache host.
-        /// </summary>
-        event EventHandler HostDisconnected;
-
-        /// <summary>
-        /// Event that fires when the cache client is successfully reconnected to a disconnected cache host.
-        /// </summary>
-        event EventHandler HostReconnected;
     }
 }

--- a/Dache.Client/Plugins/OutputCache/DacheMvcChildActionCache.cs
+++ b/Dache.Client/Plugins/OutputCache/DacheMvcChildActionCache.cs
@@ -5,17 +5,18 @@ namespace Dache.Client.Plugins.OutputCache
 {
     /// <summary>
     /// The Dache output cache provider for MVC child action caching.
-    /// TODO: make more generic, so that we also have a MemoryCache provider
+    /// TODO: make more generic, so that we also have a MemoryCache provider.
     /// </summary>
     public class DacheMvcChildActionCache : MemoryCache
     {
         // The cache key
         private const string _cacheKey = "__DacheCustomMvcChildActionOutputCaching_CacheKey:{0}";
+
         // The cache client
         private readonly ICacheClient _cacheClient = null;
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="DacheMvcChildActionCache"/> class.
         /// </summary>
         /// <param name="cacheClient">The cache client.</param>
         public DacheMvcChildActionCache(ICacheClient cacheClient) 
@@ -36,7 +37,7 @@ namespace Dache.Client.Plugins.OutputCache
         /// <param name="key">A unique identifier for the cache entry.</param>
         /// <param name="value">The object to insert.</param>
         /// <param name="absoluteExpiration">The fixed date and time at which the cache entry will expire.</param>
-        /// <param name="regionName">Ignored.</param>
+        /// <param name="regionName">Ignored parameter.</param>
         /// <returns>true if insertion succeeded, false otherwise.</returns>
         public override bool Add(string key, object value, DateTimeOffset absoluteExpiration, string regionName = null)
         {
@@ -45,6 +46,7 @@ namespace Dache.Client.Plugins.OutputCache
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "key");
             }
+
             if (value == null)
             {
                 throw new ArgumentNullException("value");
@@ -61,7 +63,7 @@ namespace Dache.Client.Plugins.OutputCache
         /// Gets the specified cache entry from the cache as an object.
         /// </summary>
         /// <param name="key">A unique identifier for the cache entry to get.</param>
-        /// <param name="regionName">Ignored.</param>
+        /// <param name="regionName">Ignored parameter.</param>
         /// <returns>The cache entry that is identified by key.</returns>
         public override object Get(string key, string regionName = null)
         {

--- a/Dache.Client/Plugins/OutputCache/DacheOutputCacheProvider.cs
+++ b/Dache.Client/Plugins/OutputCache/DacheOutputCacheProvider.cs
@@ -10,6 +10,7 @@ namespace Dache.Client.Plugins.OutputCache
     {
         // The cache key
         private const string _cacheKey = "__DacheCustomOutputCaching_CacheKey:{0}";
+
         // The cache client
         private static readonly ICacheClient _cacheClient = new CacheClient();
 

--- a/Dache.Client/Plugins/SessionState/DacheSessionState.cs
+++ b/Dache.Client/Plugins/SessionState/DacheSessionState.cs
@@ -10,52 +10,55 @@ namespace Dache.Client.Plugins.SessionState
     internal class DacheSessionState
     {
         /// <summary>
-        /// The session ID.
+        /// Gets or sets the session ID.
         /// </summary>
         public string SessionId { get; set; }
 
         /// <summary>
-        /// The application name.
+        /// Gets or sets the application name.
         /// </summary>
         public string ApplicationName { get; set; }
 
         /// <summary>
-        /// The datetime at which the object was created.
+        /// Gets or sets the datetime at which the object was created.
         /// </summary>
         public DateTime Created { get; set; }
 
         /// <summary>
-        /// The datetime at which the object expires.
+        /// Gets or sets the datetime at which the object expires.
         /// </summary>
         public DateTime Expires { get; set; }
 
         /// <summary>
-        /// The datetime at which the object was locked.
+        /// Gets or sets the datetime at which the object was locked.
         /// </summary>
         public DateTime LockDate { get; set; }
 
         /// <summary>
-        /// The lock ID.
+        /// Gets or sets the lock ID.
         /// </summary>
         public int LockId { get; set; }
 
         /// <summary>
-        /// The timeout.
+        /// Gets or sets the timeout.
         /// </summary>
         public int Timeout { get; set; }
 
         /// <summary>
-        /// Whether or not the session state is locked.
+        /// Gets or sets a value indicating whether this <see cref="DacheSessionState"/> is locked.
         /// </summary>
+        /// <value>
+        ///   <c>true</c> if locked; otherwise, <c>false</c>.
+        /// </value>
         public bool Locked { get; set; }
 
         /// <summary>
-        /// The session items.
+        /// Gets or sets the session items.
         /// </summary>
         public byte[] SessionItems { get; set; }
 
         /// <summary>
-        /// The flags.
+        /// Gets or sets the flags.
         /// </summary>
         public SessionStateActions Flags { get; set; }
     }

--- a/Dache.Client/Plugins/SessionState/DacheSessionStateProvider.cs
+++ b/Dache.Client/Plugins/SessionState/DacheSessionStateProvider.cs
@@ -15,11 +15,13 @@ namespace Dache.Client.Plugins.SessionState
     {
         // The cache key
         private const string _cacheKey = "__DacheCustomSessionState_SessionID:{0}_ApplicationName:{1}";
+
         // The cache client
         private readonly ICacheClient _cacheClient = new CacheClient();
 
         // The application name
         private string _applicationName = null;
+
         // The session state config
         private SessionStateSection _sessionStateSection = null;
 
@@ -85,19 +87,21 @@ namespace Dache.Client.Plugins.SessionState
         {
             var now = DateTime.Now;
 
-            _cacheClient.AddOrUpdate(string.Format(_cacheKey, id, _applicationName), new DacheSessionState
-            {
-                SessionId = id,
-                ApplicationName = _applicationName,
-                Created = now,
-                Expires = now,
-                LockDate = now,
-                LockId = 0,
-                Timeout = timeout,
-                Locked = false,
-                SessionItems = new byte[0],
-                Flags = SessionStateActions.InitializeItem
-            });
+            _cacheClient.AddOrUpdate(
+                string.Format(_cacheKey, id, _applicationName),
+                new DacheSessionState
+                    {
+                        SessionId = id,
+                        ApplicationName = _applicationName,
+                        Created = now,
+                        Expires = now,
+                        LockDate = now,
+                        LockId = 0,
+                        Timeout = timeout,
+                        Locked = false,
+                        SessionItems = new byte[0],
+                        Flags = SessionStateActions.InitializeItem
+                    });
         }
 
         /// <summary>
@@ -138,8 +142,10 @@ namespace Dache.Client.Plugins.SessionState
 
             // String to hold serialized SessionStateItemCollection
             byte[] serializedItems = null;
+
             // True if a record is found in the database
             bool foundRecord = false;
+
             // Timeout value from the data store
             int timeout = 0;
 
@@ -156,6 +162,7 @@ namespace Dache.Client.Plugins.SessionState
                 {
                     // The record was expired - mark it as not locked
                     locked = false;
+
                     // Delete the current session
                     _cacheClient.Remove(cacheKey);
                 }
@@ -225,7 +232,7 @@ namespace Dache.Client.Plugins.SessionState
             _cacheClient.TryGet<DacheSessionState>(cacheKey, out currentSession);
 
             // Obtain a lock if possible. Ignore the record if it is expired.
-                
+
             // Set locked to true if the record was not updated and false if it was
             locked = !(currentSession != null && !currentSession.Locked && currentSession.Expires > now);
 
@@ -320,7 +327,7 @@ namespace Dache.Client.Plugins.SessionState
         /// <param name="id">The session identifier for the current request.</param>
         /// <param name="item">The SessionStateStoreData object that contains the current session values to be stored.</param>
         /// <param name="lockId">The lock identifier for the current request.</param>
-        /// <param name="newItem">true to identify the session item as a new item; false to identify the session item as an existing item.</param>
+        /// <param name="newItem">True to identify the session item as a new item; false to identify the session item as an existing item.</param>
         public override void SetAndReleaseItemExclusive(HttpContext context, string id, SessionStateStoreData item, object lockId, bool newItem)
         {
             // Serialize the SessionStateItemCollection as a string
@@ -343,19 +350,21 @@ namespace Dache.Client.Plugins.SessionState
             _cacheClient.TryGet<DacheSessionState>(cacheKey, out currentSession);
 
             // Create or update the session item
-            _cacheClient.AddOrUpdate(cacheKey, new DacheSessionState
-            {
-                SessionId = id,
-                ApplicationName = _applicationName,
-                Created = currentSession != null ? currentSession.Created : now,
-                Expires = now.AddMinutes(item.Timeout),
-                LockDate = currentSession != null ? currentSession.LockDate : now,
-                LockId = currentSession != null ? currentSession.LockId : 0,
-                Timeout = currentSession != null ? currentSession.Timeout : item.Timeout,
-                Locked = false,
-                SessionItems = serializedItems,
-                Flags = currentSession != null ? currentSession.Flags : SessionStateActions.None
-            });
+            _cacheClient.AddOrUpdate(
+                cacheKey, 
+                new DacheSessionState
+                    {
+                        SessionId = id,
+                        ApplicationName = _applicationName,
+                        Created = currentSession != null ? currentSession.Created : now,
+                        Expires = now.AddMinutes(item.Timeout),
+                        LockDate = currentSession != null ? currentSession.LockDate : now,
+                        LockId = currentSession != null ? currentSession.LockId : 0,
+                        Timeout = currentSession != null ? currentSession.Timeout : item.Timeout,
+                        Locked = false,
+                        SessionItems = serializedItems,
+                        Flags = currentSession != null ? currentSession.Flags : SessionStateActions.None
+                    });
         }
 
         /// <summary>

--- a/Dache.Client/Serialization/GZipSerializer.cs
+++ b/Dache.Client/Serialization/GZipSerializer.cs
@@ -17,7 +17,6 @@ namespace Dache.Client.Serialization
         /// <returns>
         /// A byte array of the serialized object, or null if the object was null.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">value;Can't compress null value</exception>
         public byte[] Serialize(object value)
         {
             // Sanitize
@@ -42,7 +41,7 @@ namespace Dache.Client.Serialization
         /// </summary>
         /// <param name="bytes">The byte array that should be decompressed and deserialized.</param>
         /// <returns>
-        /// A deserialized and decomressed object, or null if the byte array was null.
+        /// A deserialized and decompressed object, or null if the byte array was null.
         /// </returns>
         public object Deserialize(byte[] bytes)
         {

--- a/Dache.Client/Serialization/IBinarySerializer.cs
+++ b/Dache.Client/Serialization/IBinarySerializer.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Dache.Client.Serialization
+﻿namespace Dache.Client.Serialization
 {
     /// <summary>
     /// Represents a binary serializer. You can implement this interface to inject your own custom serialization into a Dache client.

--- a/Dache.Client/Settings.StyleCop
+++ b/Dache.Client/Settings.StyleCop
@@ -1,0 +1,6 @@
+﻿<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <StringProperty Name="LinkedSettingsFile">..\Settings.StyleCop</StringProperty>
+    <StringProperty Name="MergeSettingsFiles">Linked</StringProperty>
+  </GlobalSettings>
+</StyleCopSettings>

--- a/Dache.Client/packages.config
+++ b/Dache.Client/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="SharpMemoryCache" version="1.0.0" targetFramework="net45" />
   <package id="SimplSockets" version="1.1.1" targetFramework="net45" />
+  <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Dache.Core/Communication/DacheProtocolHelper.cs
+++ b/Dache.Core/Communication/DacheProtocolHelper.cs
@@ -10,6 +10,11 @@ namespace Dache.Core.Communication
     public static class DacheProtocolHelper
     {
         /// <summary>
+        /// The absolute expiration format.
+        /// </summary>
+        public const string AbsoluteExpirationFormat = "yyMMddhhmmss";
+
+        /// <summary>
         /// The communication encoding.
         /// </summary>
         public static readonly Encoding CommunicationEncoding = Encoding.UTF8;
@@ -23,11 +28,6 @@ namespace Dache.Core.Communication
         /// The byte that represents a space.
         /// </summary>
         public static readonly byte[] SpaceByte = CommunicationEncoding.GetBytes(" ");
-
-        /// <summary>
-        /// The absolute expiration format.
-        /// </summary>
-        public const string AbsoluteExpirationFormat = "yyMMddhhmmss";
 
         /// <summary>
         /// The message type.

--- a/Dache.Core/Comparers/GenericComparer.cs
+++ b/Dache.Core/Comparers/GenericComparer.cs
@@ -13,7 +13,7 @@ namespace Dache.Core.Comparers
         private readonly Func<T, T, int> _comparerFunc = null;
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="GenericComparer{T}"/> class.
         /// </summary>
         /// <param name="comparerFunc">The function which compares two objects.</param>
         public GenericComparer(Func<T, T, int> comparerFunc)
@@ -32,7 +32,7 @@ namespace Dache.Core.Comparers
         /// </summary>
         /// <param name="x">The first object.</param>
         /// <param name="y">The second object.</param>
-        /// <returns>-1 if x is less than y, 1 if x is greater than y, and 0 if the two are equal.</returns>
+        /// <returns>An integer, -1 if x is less than y, 1 if x is greater than y, and 0 if the two are equal.</returns>
         public int Compare(T x, T y)
         {
             return _comparerFunc(x, y);

--- a/Dache.Core/Dache.Core.csproj
+++ b/Dache.Core/Dache.Core.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>5cd275a9</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,7 +57,18 @@
     <Compile Include="Routing\ITagRoutingTable.cs" />
     <Compile Include="Routing\TagRoutingTable.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Settings.StyleCop" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Dache.Core/Logging/EventViewerLogger.cs
+++ b/Dache.Core/Logging/EventViewerLogger.cs
@@ -13,7 +13,7 @@ namespace Dache.Core.Logging
         private readonly EventLog _eventLog = null;
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="EventViewerLogger"/> class.
         /// </summary>
         /// <param name="source">The source name by which the application is registered on the local computer.</param>
         /// <param name="logName">The name of the log the source's entries are written to.</param>
@@ -24,6 +24,7 @@ namespace Dache.Core.Logging
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "source");
             }
+
             if (string.IsNullOrWhiteSpace(logName))
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "logName");

--- a/Dache.Core/Logging/FileLogger.cs
+++ b/Dache.Core/Logging/FileLogger.cs
@@ -13,7 +13,7 @@ namespace Dache.Core.Logging
         private readonly string _filePath = null;
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="FileLogger"/> class.
         /// </summary>
         /// <param name="fileName">The name of the log file to write to. Defaults to "log.txt" if not specified.</param>
         public FileLogger(string fileName = "log.txt")

--- a/Dache.Core/Performance/CustomPerformanceCounterInstaller.cs
+++ b/Dache.Core/Performance/CustomPerformanceCounterInstaller.cs
@@ -32,6 +32,7 @@ namespace Dache.Core.Performance
             {
                 PerformanceCounterCategory.Delete(_performanceCounterCategoryName);
             }
+
             // Create performance counter category
             PerformanceCounterCategory.Create(_performanceCounterCategoryName, "Performance counters related to Dache services", PerformanceCounterCategoryType.MultiInstance, counterCreationDataCollection);
         }

--- a/Dache.Core/Performance/CustomPerformanceCounterManager.cs
+++ b/Dache.Core/Performance/CustomPerformanceCounterManager.cs
@@ -11,11 +11,12 @@ namespace Dache.Core.Performance
     {
         // The performance counter category name
         private const string _performanceCounterCategoryName = "Dache";
+
         // The performance counters
         private readonly IDictionary<string, PerformanceCounter> _performanceCounters = new Dictionary<string, PerformanceCounter>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// The constructor. Initializes local performance counters.
+        /// Initializes a new instance of the <see cref="CustomPerformanceCounterManager"/> class.
         /// </summary>
         /// <param name="performanceCounterInstanceName">The performance counter instance name.</param>
         /// <param name="readOnly">Whether or not the performance counters are read-only.</param>
@@ -62,7 +63,7 @@ namespace Dache.Core.Performance
         }
 
         /// <summary>
-        /// The constructor. Initializes remote performance counters.
+        /// Initializes a new instance of the <see cref="CustomPerformanceCounterManager"/> class.
         /// </summary>
         /// <param name="machineName">The machine name.</param>
         /// <param name="performanceCounterInstanceName">The performance counter instance name.</param>
@@ -73,6 +74,7 @@ namespace Dache.Core.Performance
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "machineName");
             }
+
             if (string.IsNullOrWhiteSpace(performanceCounterInstanceName))
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "performanceCounterInstanceName");
@@ -128,9 +130,49 @@ namespace Dache.Core.Performance
         }
 
         /// <summary>
+        /// Gets the number of cached objects.
+        /// </summary>
+        public PerformanceCounter NumberOfCachedObjects { get; private set; }
+
+        /// <summary>
+        /// Gets the total requests per second.
+        /// </summary>
+        public PerformanceCounter TotalRequestsPerSecond { get; private set; }
+
+        /// <summary>
+        /// Gets the cache memory usage percent.
+        /// </summary>
+        public PerformanceCounter CacheMemoryUsagePercent { get; private set; }
+
+        /// <summary>
+        /// Gets the cache memory usage base percent.
+        /// </summary>
+        public PerformanceCounter CacheMemoryUsageBasePercent { get; private set; }
+
+        /// <summary>
+        /// Gets the cache memory usage in megabytes.
+        /// </summary>
+        public PerformanceCounter CacheMemoryUsageMb { get; private set; }
+
+        /// <summary>
+        /// Gets the number of adds per second.
+        /// </summary>
+        public PerformanceCounter AddsPerSecond { get; private set; }
+
+        /// <summary>
+        /// Gets the number of gets per second.
+        /// </summary>
+        public PerformanceCounter GetsPerSecond { get; private set; }
+
+        /// <summary>
+        /// Gets the number of removes per second.
+        /// </summary>
+        public PerformanceCounter RemovesPerSecond { get; private set; }
+
+        /// <summary>
         /// Attempts to get a performance counter by its name.
         /// </summary>
-        /// <param name="name">The name.</param>
+        /// <param name="name">The performance counter name.</param>
         /// <param name="performanceCounter">The performance counter.</param>
         /// <returns>true if successful, false otherwise.</returns>
         public bool TryGetPerformanceCounter(string name, out PerformanceCounter performanceCounter)
@@ -158,46 +200,6 @@ namespace Dache.Core.Performance
                 performanceCounter.NextValue();
             }
         }
-
-        /// <summary>
-        /// The number of cached objects.
-        /// </summary>
-        public PerformanceCounter NumberOfCachedObjects { get; private set; }
-
-        /// <summary>
-        /// The total requests per second.
-        /// </summary>
-        public PerformanceCounter TotalRequestsPerSecond { get; private set; }
-
-        /// <summary>
-        /// The cache memory usage percent.
-        /// </summary>
-        public PerformanceCounter CacheMemoryUsagePercent { get; private set; }
-        
-        /// <summary>
-        /// The cache memory usage base percent.
-        /// </summary>
-        public PerformanceCounter CacheMemoryUsageBasePercent { get; private set; }
-
-        /// <summary>
-        /// The cache memory usage in megabytes.
-        /// </summary>
-        public PerformanceCounter CacheMemoryUsageMb { get; private set; }
-
-        /// <summary>
-        /// The adds per second.
-        /// </summary>
-        public PerformanceCounter AddsPerSecond { get; private set; }
-        
-        /// <summary>
-        /// The gets per second.
-        /// </summary>
-        public PerformanceCounter GetsPerSecond { get; private set; }
-
-        /// <summary>
-        /// The removes per second.
-        /// </summary>
-        public PerformanceCounter RemovesPerSecond { get; private set; }
 
         /// <summary>
         /// Called when disposed.

--- a/Dache.Core/Performance/ICustomPerformanceCounterManager.cs
+++ b/Dache.Core/Performance/ICustomPerformanceCounterManager.cs
@@ -10,9 +10,49 @@ namespace Dache.Core.Performance
     public interface ICustomPerformanceCounterManager : IDisposable
     {
         /// <summary>
+        /// Gets the number of cached objects.
+        /// </summary>
+        PerformanceCounter NumberOfCachedObjects { get; }
+
+        /// <summary>
+        /// Gets the total requests per second.
+        /// </summary>
+        PerformanceCounter TotalRequestsPerSecond { get; }
+
+        /// <summary>
+        /// Gets the cache memory usage percent.
+        /// </summary>
+        PerformanceCounter CacheMemoryUsagePercent { get; }
+
+        /// <summary>
+        /// Gets the cache memory usage base percent.
+        /// </summary>
+        PerformanceCounter CacheMemoryUsageBasePercent { get; }
+
+        /// <summary>
+        /// Gets the cache memory usage in megabytes.
+        /// </summary>
+        PerformanceCounter CacheMemoryUsageMb { get; }
+
+        /// <summary>
+        /// Gets the adds per second.
+        /// </summary>
+        PerformanceCounter AddsPerSecond { get; }
+
+        /// <summary>
+        /// Gets the gets per second.
+        /// </summary>
+        PerformanceCounter GetsPerSecond { get; }
+
+        /// <summary>
+        /// Gets the removes per second.
+        /// </summary>
+        PerformanceCounter RemovesPerSecond { get; }
+
+        /// <summary>
         /// Attempts to get a performance counter by its name.
         /// </summary>
-        /// <param name="name">The name.</param>
+        /// <param name="name">The performance counter name.</param>
         /// <param name="performanceCounter">The performance counter.</param>
         /// <returns>true if successful, false otherwise.</returns>
         bool TryGetPerformanceCounter(string name, out PerformanceCounter performanceCounter);
@@ -27,45 +67,5 @@ namespace Dache.Core.Performance
         /// Updates all performance counters.
         /// </summary>
         void UpdateAll();
-
-        /// <summary>
-        /// The number of cached objects.
-        /// </summary>
-        PerformanceCounter NumberOfCachedObjects { get; }
-
-        /// <summary>
-        /// The total requests per second.
-        /// </summary>
-        PerformanceCounter TotalRequestsPerSecond { get; }
-
-        /// <summary>
-        /// The cache memory usage percent.
-        /// </summary>
-        PerformanceCounter CacheMemoryUsagePercent { get; }
-
-        /// <summary>
-        /// The cache memory usage base percent.
-        /// </summary>
-        PerformanceCounter CacheMemoryUsageBasePercent { get; }
-
-        /// <summary>
-        /// The cache memory usage in megabytes.
-        /// </summary>
-        PerformanceCounter CacheMemoryUsageMb { get; }
-
-        /// <summary>
-        /// The adds per second.
-        /// </summary>
-        PerformanceCounter AddsPerSecond { get; }
-
-        /// <summary>
-        /// The gets per second.
-        /// </summary>
-        PerformanceCounter GetsPerSecond { get; }
-
-        /// <summary>
-        /// The removes per second.
-        /// </summary>
-        PerformanceCounter RemovesPerSecond { get; }
     }
 }

--- a/Dache.Core/Routing/ITagRoutingTable.cs
+++ b/Dache.Core/Routing/ITagRoutingTable.cs
@@ -18,7 +18,7 @@ namespace Dache.Core.Routing
         /// <summary>
         /// Removes the given cache key from the routing table.
         /// </summary>
-        /// <param name="cacheKey">the cache key.</param>
+        /// <param name="cacheKey">The cache key.</param>
         void Remove(string cacheKey);
 
         /// <summary>

--- a/Dache.Core/Routing/TagRoutingTable.cs
+++ b/Dache.Core/Routing/TagRoutingTable.cs
@@ -13,13 +13,15 @@ namespace Dache.Core.Routing
     {
         // The tagged cache keys: key is tag name, value is cache keys
         private readonly IDictionary<string, HashSet<string>> _taggedCacheKeys;
+
         // The cache keys and their associated tags: key is cache key, value is tag name
         private readonly IDictionary<string, string> _cacheKeyTags;
+        
         // The lock used to ensure thread safety
         private readonly ReaderWriterLockSlim _lock;
 
         /// <summary>
-        /// The constructor.
+        /// Initializes a new instance of the <see cref="TagRoutingTable"/> class.
         /// </summary>
         public TagRoutingTable()
         {
@@ -41,6 +43,7 @@ namespace Dache.Core.Routing
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "cacheKey");
             }
+
             if (string.IsNullOrWhiteSpace(tagName))
             {
                 throw new ArgumentException("cannot be null, empty, or white space", "tagName");
@@ -68,7 +71,7 @@ namespace Dache.Core.Routing
         /// <summary>
         /// Removes the given cache key from the routing table.
         /// </summary>
-        /// <param name="cacheKey">the cache key.</param>
+        /// <param name="cacheKey">The cache key.</param>
         public void Remove(string cacheKey)
         {
             // Sanitize
@@ -134,9 +137,10 @@ namespace Dache.Core.Routing
                 }
 
                 var r = new Regex(pattern, RegexOptions.IgnoreCase);
+
                 // Return a copy of the cache keys
                 return cacheKeys.Where(k => r.IsMatch(k)).ToList();
-            }// no catch block?
+            }
             finally
             {
                 _lock.ExitReadLock();

--- a/Dache.Core/Settings.StyleCop
+++ b/Dache.Core/Settings.StyleCop
@@ -1,0 +1,6 @@
+﻿<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <StringProperty Name="LinkedSettingsFile">..\Settings.StyleCop</StringProperty>
+    <StringProperty Name="MergeSettingsFiles">Linked</StringProperty>
+  </GlobalSettings>
+</StyleCopSettings>

--- a/Dache.Core/packages.config
+++ b/Dache.Core/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/Dache.sln
+++ b/Dache.sln
@@ -24,6 +24,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dache.Tests", "Dache.Tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dache.PerformanceTests", "Dache.PerformanceTests\Dache.PerformanceTests.csproj", "{873B44C2-D7DA-4040-8605-30D6795D669D}"
 EndProject
+Project("{CC5FD16D-436D-48AD-A40C-5A424C6E3E79}") = "AzureWorker", "AzureWorker\AzureWorker.ccproj", "{D74CD595-DC0F-44ED-B3E4-8A104B5537F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkerRole1", "WorkerRole1\WorkerRole1.csproj", "{39D2281F-4866-4EF5-A1C4-B86D1E455E20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,6 +58,14 @@ Global
 		{873B44C2-D7DA-4040-8605-30D6795D669D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{873B44C2-D7DA-4040-8605-30D6795D669D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{873B44C2-D7DA-4040-8605-30D6795D669D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D74CD595-DC0F-44ED-B3E4-8A104B5537F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D74CD595-DC0F-44ED-B3E4-8A104B5537F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D74CD595-DC0F-44ED-B3E4-8A104B5537F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D74CD595-DC0F-44ED-B3E4-8A104B5537F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39D2281F-4866-4EF5-A1C4-B86D1E455E20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39D2281F-4866-4EF5-A1C4-B86D1E455E20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39D2281F-4866-4EF5-A1C4-B86D1E455E20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39D2281F-4866-4EF5-A1C4-B86D1E455E20}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Dache.sln
+++ b/Dache.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.30110.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3DBCCF8F-343C-455F-A8C5-F23B8A2E6B75}"
 	ProjectSection(SolutionItems) = preProject
 		LICENSE.txt = LICENSE.txt
 		README.md = README.md
+		Settings.StyleCop = Settings.StyleCop
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 		TODO.txt = TODO.txt
 	EndProjectSection

--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -1,0 +1,110 @@
+<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <CollectionProperty Name="DeprecatedWords">
+      <Value>preprocessor, pre-processor</Value>
+      <Value>shortlived, short-lived</Value>
+    </CollectionProperty>
+    <CollectionProperty Name="RecognizedWords">
+      <Value>asax</Value>
+      <Value>cookieless</Value>
+      <Value>Dache</Value>
+      <Value>Dacheboard</Value>
+      <Value>datetime</Value>
+      <Value>mem</Value>
+      <Value>poller</Value>
+      <Value>reg</Value>
+    </CollectionProperty>
+  </GlobalSettings>
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.NamingRules">
+      <Rules>
+        <Rule Name="ConstFieldNamesMustBeginWithUpperCaseLetter">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FieldNamesMustNotBeginWithUnderscore">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="StaticReadonlyFieldsMustBeginWithUpperCaseLetter">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings>
+        <CollectionProperty Name="Hungarian">
+          <Value>as</Value>
+          <Value>do</Value>
+          <Value>id</Value>
+          <Value>if</Value>
+          <Value>in</Value>
+          <Value>ip</Value>
+          <Value>is</Value>
+          <Value>my</Value>
+          <Value>no</Value>
+          <Value>on</Value>
+          <Value>to</Value>
+          <Value>ui</Value>
+        </CollectionProperty>
+      </AnalyzerSettings>
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="ElementsMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustBeginWithACapitalLetter">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustEndWithAPeriod">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustMeetMinimumCharacterLength">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileMustHaveHeader">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.OrderingRules">
+      <Rules>
+        <Rule Name="UsingDirectivesMustBePlacedWithinNamespace">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
+      <Rules>
+        <Rule Name="PrefixLocalCallsWithThis">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PrefixCallsCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -22,5 +22,6 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.3.0.*")]
+
 // For unit testing
 [assembly: InternalsVisibleTo("Dache.Tests")]


### PR DESCRIPTION
First of all, StyleCop is not FxCop. I always like to precise this as people tend to make confusion. StyleCop enforces rules about the coding style and is used to maintain coding style uniform across projects and between developers.
I have chosen to add the StyleCop as a NuGet package dependency. This has several advantages. First of all, upgrade to the newer versions is trivial, and adding new projects is way more straight forward. With the package I have chosen are shipped all the necessary tools to run StyleCop, both local and on build server, with no need to install any additional tool on developers PC or the build server. Package contains StyleCop dlls, a GUI app that allows us to modify the rules, and other configuration files. Once the package is added, your project file will also be modified. You will find a pointer to .Targets file which is the essential piece in this game. It contains the necessary configuration in order to put the StyleCop analyzes in place.
This is a good start, still we need some fine tuning. However, right away you can compile you project/s and you will be able to notice the big amount of warning starting wit SA. Now this means that we are breaking several StyleCop rules? Wait a minute, what rules, I haven't chose anything! Well that's right, however once added all the rules are considered valid or active. If the default set of rules doesn't fit your coding guideline or you do not share the same opinion about certain rules with the guys who created StyleCop, you will need to disable this rules. We will disable rules per solution as we do want all of our projects to use the same rules so that we can have consistent style across all our projects. In order to do so, on the project level we will add a configuration file in our solution root. A template for this file can be found in the packages tolls file. All we need is to copy that file from the original path to the root of our solution. Once added, link it in your solution from Visual Studio by adding an existing file to our " Solution Items" solution folder.
Before we start changing the rules we need to explain to StyleCop that this is the file that should be used as the valid settings file. This operation is done locally from the every single project on which StyleCop is enabled. Add in the root folder of your project a file called Settings.StyleCop and add the following in it. The important thing is that StringProperty LinkedSettingsFile is pointing to the setting files in our solution root. Once this is done for every project we enabled Style Cop on we can start modifying the rules.
In order to modify the rules, open the command prompt and position yourself inside the packages directory of your project, more precisely in StyleCop.MSBuild.4.7.49.0\tools folder. Now execute the settings editor passing as the parameter the lionk to your settings file. In my case the command will look like this, StyleCopSettingsEditor "C:\Users\MaiO\Code\dache\Settings.StyleCop". This will open the editor, you can track the rules easly by theire description. Each rule name in your warnings do start wit the code that identifies that rule in the unique way. Right after the code there is the group name of which that rule is part of. This will help you to locate the rule in the editor. Once found the rule you do not want to be applied on your project, deselect it and click apply. If you now recompile your project, no more warnings for that rule should be visible.
At a certain point you will notice SA1650: CSharp.Documentation warning appearing. This is used to indicate an incorrectly spelled word. A dictionary that you can find in the packages folder is use to perform spell checking. In case a ward that is valid is not recognized, you can add the exception in your solution level Settings.StyleCop file. The only thing you will need to do is add the following to that file and then list all of your words one by one inside of value elements. The same thing is achievable also through settings editor, however it is I think quicker to directly modify the settings file. Still, if the editor is opened, do not modify the underlying file, as any further change in the editor will make you lose the manually edited file changes.
This should be enough to start using it. There is still one option that I will not activate at this point. It is about treating the warnings as errors. Braking StyleCop rules will prevent to have a successful build.
