### PR TITLE
Address list is empty

### DIFF
--- a/Dache.Client/CommunicationClient.cs
+++ b/Dache.Client/CommunicationClient.cs
@@ -68,7 +68,7 @@ namespace Dache.Client
 
             // Establish the remote endpoint for the socket
             var ipHostInfo = Dns.GetHostEntry(address);
-            var ipAddress = ipHostInfo.AddressList.First(i => i.AddressFamily == AddressFamily.InterNetwork);
+            var ipAddress = ipHostInfo.AddressList.FirstOrDefault(i => i.AddressFamily == AddressFamily.InterNetwork) ?? IPAddress.Parse(address);
             _remoteEndPoint = new IPEndPoint(ipAddress, port);
 
             // Set the cache host reconnect interval


### PR DESCRIPTION
If the Dns.GetHostEntry resolved an empty addresslist, one gets an exception. In that case it can just parse the address directly.
